### PR TITLE
Set the I2S pins in the ctor.

### DIFF
--- a/eStreamPlayer32.ino
+++ b/eStreamPlayer32.ino
@@ -105,7 +105,7 @@ struct {
   uint32_t clientId;
 } deletefavorite;
 
-Audio audio;
+Audio audio(I2S_BCK, I2S_WS, I2S_DOUT);
 playList playList;
 AsyncWebServer server(80);
 AsyncWebSocket ws("/ws");
@@ -573,7 +573,6 @@ void setup() {
   ESP_LOGI(TAG, "Starting I2S dac");
 #endif
 
-  audio.setPinout(I2S_BCK, I2S_WS, I2S_DOUT);
   audio.setVolume(5); /* max 21 */
 
   xTaskCreatePinnedToCore(

--- a/eStreamPlayer32.ino
+++ b/eStreamPlayer32.ino
@@ -68,7 +68,7 @@ enum {
 
 int currentItem {NOTHING_PLAYING};
 
-bool volumeUpdate{false};
+bool volumeIsUpdated{false};
 
 struct {
   uint32_t id;
@@ -189,7 +189,7 @@ void onEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTyp
           if (pch) {
             const uint8_t volume = atoi(pch);
             audio.setVolume(volume > I2S_MAX_VOLUME ? I2S_MAX_VOLUME : volume);
-            volumeUpdate = true;
+            volumeIsUpdated = true;
           }
           return;
         }
@@ -321,8 +321,8 @@ void onEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTyp
                  !strcmp("_favoritetoplaylist", pch)) {
           const bool startnow = (pch[0] == '_');
           favoriteToPlaylist.name = strtok(NULL, "\n");
-          favoriteToPlaylist.requested = true;
           favoriteToPlaylist.startNow = startnow;
+          favoriteToPlaylist.requested = true;
         }
 
         else if (!strcmp("deletefavorite", pch)) {
@@ -612,9 +612,9 @@ void loop() {
       previousPos = audio.getFilePos();
     }
   */
-  if (volumeUpdate) {
+  if (volumeIsUpdated) {
     ws.textAll(VOLUME_HEADER + String(audio.getVolume()));
-    volumeUpdate = false;
+    volumeIsUpdated = false;
   }
 
   if (playList.isUpdated) {

--- a/htmlEntities.h
+++ b/htmlEntities.h
@@ -4,10 +4,10 @@ String htmlEntities(const char* plaintext) {
   String result{};
   uint32_t cnt{0};
   while (plaintext[cnt] != 0) {
-    if (plaintext[cnt] >= 0xA0) {
+    if (plaintext[cnt] > 128) {
       switch (plaintext[cnt]) {
 
-        case 0xC2 :                                 //UTF-8 16bit encoding - just copy
+        case 0xC2 :                                 //UTF-8 16bit encoding - just copy 2 bytes to result
         case 0xC3 :
           result.concat(plaintext[cnt]);
           cnt++;


### PR DESCRIPTION
Default pins of ESP32-audioI2S interfered with other hardware. (for example M5Stack lcd)
This is fixed by setting the pins in the contructor.

See schreibfaul1/ESP32-audioI2S/issues/70 and https://github.com/schreibfaul1/ESP32-audioI2S/commit/b9f787eed85be1640b1eb1fc3f217b74d66810fb

Same pin order as 'audio.setPinout()'.